### PR TITLE
Fixes #27: .desktop file supports configurable MimeType entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,11 @@ Categories in which the application should be shown in a menu, used in the [`Cat
 
 For possible values check out the [Desktop Menu Specification](http://standards.freedesktop.org/menu-spec/latest/apa.html).
 
+#### options.mimeType
+Type: `Array[String]`
+Default: `[]`
+
+MIME types the application is able to open, used in the [`MimeType` field of the `desktop` specification](http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html).
 
 ## Meta
 

--- a/resources/desktop.ejs
+++ b/resources/desktop.ejs
@@ -7,4 +7,5 @@
 <% } %>Type=Application
 StartupNotify=true
 <% if (categories && categories.length) { %>Categories=<%= categories.join(';') %>;
-<% } %>MimeType=text/plain;
+<% } %><% if (mimeType && mimeType.length) { %>MimeType=<%= mimeType.join(';') %>;
+<% } %>

--- a/src/installer.js
+++ b/src/installer.js
@@ -128,7 +128,9 @@ var getDefaults = function (data, callback) {
         'GNOME',
         'GTK',
         'Utility'
-      ]
+      ],
+
+      mimeType: []
     }
 
     callback(err, defaults)

--- a/test/installer.js
+++ b/test/installer.js
@@ -56,6 +56,9 @@ describe('module', function () {
           arch: 'x86_64',
           categories: [
             'Utility'
+          ],
+          mimeType: [
+            'text/plain'
           ]
         }
       }, done)


### PR DESCRIPTION
- adds support for MimeType entry in .desktop file
- shamelessly copies what was done in  electron-installer-debian change (see https://github.com/unindented/electron-installer-debian/commit/70586c5dfeb25437839531c9141bf7b8c9b926de) as files that can be identical seem to be between these repos