### PR TITLE
Allow setting different mime types in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,13 @@ Categories in which the application should be shown in a menu, used in the [`Cat
 
 For possible values check out the [Desktop Menu Specification](http://standards.freedesktop.org/menu-spec/latest/apa.html).
 
+#### options.mimes
+Type: `Array[String]`
+Default: `['text/plain']`
+
+Allow associating the application with different MIME-types. For exmaple if you are developing a music player you may want to associate the application with one or more audio MIME-types.
+
+[List with popular mime types](https://www.iana.org/assignments/media-types/media-types.xhtml)
 
 ## Meta
 

--- a/resources/desktop.ejs
+++ b/resources/desktop.ejs
@@ -7,4 +7,6 @@
 <% } %>Type=Application
 StartupNotify=true
 <% if (categories && categories.length) { %>Categories=<%= categories.join(';') %>;
-<% } %>MimeType=text/plain;
+<% } %>
+<% if (mimes && mimes.length) { %>MimeType=<%= mimes.join(';') %>;
+<% } %>

--- a/src/installer.js
+++ b/src/installer.js
@@ -130,7 +130,7 @@ var getDefaults = function (data, callback) {
         'Utility'
       ],
 
-      mimes : [
+      mimes: [
         'text/plain'
       ]
     }

--- a/src/installer.js
+++ b/src/installer.js
@@ -128,6 +128,10 @@ var getDefaults = function (data, callback) {
         'GNOME',
         'GTK',
         'Utility'
+      ],
+
+      mimes : [
+        'text/plain'
       ]
     }
 


### PR DESCRIPTION
Most applications need to set different MEME-types in the `.desktop` launcher, which they can handle.

For example a browser application may need to set:

    MimeType=text/html;text/xml;application/xhtml_xml;image/webp;x-scheme-handler/http;x-scheme-handler/https;

While a music player will need:

    MimeType=audio/ogg;audio/mp4;

This PR allows setting this in the config file, while the default option remains `text/plain` .