### PR TITLE
Add compressionLevel option, preserve symbolic link when building on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,12 @@ Default: `package.homepage || package.author.url`
 
 URL of the homepage for the package, used in the [`Homepage` field of the `control` specification](https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Creating_a_SPEC_file).
 
+#### options.compressionLevel
+Type: `Number`
+Default: `2`
+
+Package compression level, from `0` to `9`.
+
 #### options.bin
 Type: `String`
 Default: `package.name`

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -16,7 +16,7 @@ AutoReqProv: no
 
 %install
 mkdir -p %{buildroot}/usr/
-cp -r usr/* %{buildroot}/usr/
+<% if (process.platform != 'darwin') { %>cp -r usr/* %{buildroot}/usr/<% } else { %>cp -R usr/* %{buildroot}/usr/<% } %>
 
 %files
 /usr/bin/<%= name %>

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -12,6 +12,8 @@ AutoReqProv: no
 %description
 <%= productDescription %>
 <% } %>
+%define _binary_payload w<%= compressionLevel %>.xzdio
+
 %install
 mkdir -p %{buildroot}/usr/
 cp -r usr/* %{buildroot}/usr/

--- a/src/installer.js
+++ b/src/installer.js
@@ -121,6 +121,7 @@ var getDefaults = function (data, callback) {
         : pkg.author.url
       )),
 
+      compressionLevel: 2,
       bin: pkg.name || 'electron',
       icon: path.resolve(__dirname, '../resources/icon.png'),
 


### PR DESCRIPTION
This PR fixes copying of a symbolic link (in usr/bin) on macOS - should use `cp -R` instead of `cp -r` on this platform. 

Also added the `compressionLevel` option, default is 2, but I was able to reduce the size of my package from 51MB to 37MB just by specifying level 9.