### PR TITLE
Handle the case where no homepage is specified anywhere

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -91,6 +91,24 @@ var readLicense = function (options, callback) {
 }
 
 /**
+ * Determine the homepage based on the settings in `package.json`.
+ */
+var getHomepage = function (pkg) {
+  if (pkg.homepage) {
+    return pkg.homepage
+  } else if (pkg.author) {
+    if (typeof pkg.author === 'string') {
+      var homepageRegexp = /.*\(([^)]+)\).*/
+      if (homepageRegexp.test(pkg.author)) {
+        return pkg.author.replace(homepageRegexp, '$1')
+      }
+    } else {
+      return pkg.author.url
+    }
+  }
+}
+
+/**
  * Get the hash of default options for the installer. Some come from the info
  * read from `package.json`, and some are hardcoded.
  */
@@ -116,10 +134,7 @@ var getDefaults = function (data, callback) {
         'lsb'
       ],
 
-      homepage: pkg.homepage || (pkg.author && (typeof pkg.author === 'string'
-        ? pkg.author.replace(/.*\(([^)]+)\).*/, '$1')
-        : pkg.author.url
-      )),
+      homepage: getHomepage(pkg),
 
       compressionLevel: 2,
       bin: pkg.name || 'electron',

--- a/test/installer.js
+++ b/test/installer.js
@@ -2,8 +2,9 @@
 
 var installer = require('..')
 
+var fs = require('fs-extra')
+var os = require('os')
 var path = require('path')
-var rimraf = require('rimraf')
 var access = require('./helpers/access')
 
 describe('module', function () {
@@ -28,7 +29,7 @@ describe('module', function () {
     })
 
     after(function (done) {
-      rimraf(dest, done)
+      fs.remove(dest, done)
     })
 
     it('generates a `.rpm` package', function (done) {
@@ -63,9 +64,37 @@ describe('module', function () {
         }
       }, done)
     })
+  })
+
+  describe('with an app without a homepage or author URL', function (test) {
+    var baseDir = path.join(os.tmpdir(), 'electron-installer-redhat', 'app-without-homepage')
+    var dest = 'test/fixtures/out/baz/'
+
+    before(function (done) {
+      if (fs.existsSync(baseDir)) {
+        fs.removeSync(baseDir)
+      }
+      fs.copySync('test/fixtures/app-without-asar', baseDir)
+      var packageJSONFilename = path.join(baseDir, 'resources', 'app', 'package.json')
+      var packageJSON = JSON.parse(fs.readFileSync(packageJSONFilename))
+      packageJSON.author = 'Test Author'
+      fs.writeFileSync(packageJSONFilename, JSON.stringify(packageJSON))
+      installer({
+        src: baseDir,
+        dest: dest,
+        rename: function (dest) {
+          return path.join(dest, '<%= name %>.<%= arch %>.rpm')
+        },
+
+        options: {
+          arch: 'x86_64'
+        }
+      }, done)
+    })
 
     after(function (done) {
-      rimraf(dest, done)
+      fs.removeSync(baseDir)
+      fs.remove(dest, done)
     })
 
     it('generates a `.rpm` package', function (done) {


### PR DESCRIPTION
Solves the bug where `homepage` in `package.json` is not specified, nor is there a match for a URL in the string version of the `author` field.

I ran into this while fixing some Electron Forge tests.

I wasn't really interested in committing another fixture just to change one `package.json` field, so I have the test copy the `app-without-asar` fixture to `os.tmpdir()` and modify/operate on that directory.

I also took the liberty of removing references to `rimraf` in `test/installer.js`, since `fs-extra` provides `remove*()` functions.