### PR TITLE
Run update-desktop-database after [un]install

### DIFF
--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -26,3 +26,9 @@ mkdir -p %{buildroot}/usr/
 <% if (_.isObject(icon)) { %><% _.forEach(icon, function (path, resolution) { %>/usr/share/icons/hicolor/<%= resolution %>/apps/<%= name %>.png
 <% }) } else { %>/usr/share/pixmaps/<%= name %>.png
 <% } %>
+
+%post
+update-desktop-database &> /dev/null
+
+%postun
+update-desktop-database &> /dev/null


### PR DESCRIPTION
Ensures the newly installed icon appears in menus. Otherwise the new program
may not appear until after logging out and back in again.

Supported by GNOME, KDE, others.

This command makes app menus aware of the the newly installed .desktop file.