### PR TITLE
Include libXScrnSaver as a default dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Machine architecture the package is targeted to, used to set the `--target` opti
 
 #### options.requires
 Type: `Array[String]`
-Default: `['lsb']`
+Default: `["lsb", "libXScrnSaver"]`
 
 Packages that are required when the program starts, used in the [`Requires` field of the `spec` file](https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Creating_a_SPEC_file).
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -114,7 +114,8 @@ var getDefaults = function (data, callback) {
       arch: undefined,
 
       requires: [
-        'lsb'
+        'lsb',
+        'libXScrnSaver'
       ],
 
       homepage: util.getHomePage(pkg),


### PR DESCRIPTION
Installing the RPM on a clean copy of the latest Fedora gives the following error:

```
/usr/share/atom/atom: error while loading shared libraries: libXss.so.1: cannot open shared object file: No such file or directory
```

I found a [related issue that hit Atom itself](https://github.com/atom/atom/issues/13176). The resolution was to install libXScrnSaver. Rather than require all users to do this I added it as a default dependency. This is the same solution Atom implemented.

I did verify with libXScrnSaver now included as a requirement I can now install the package and run it without error.