### PR TITLE
Install binary files to /usr/lib/ instead of /usr/share/

### DIFF
--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -20,7 +20,7 @@ mkdir -p %{buildroot}/usr/
 
 %files
 /usr/bin/<%= name %>
-/usr/share/<%= name %>/
+/usr/lib/<%= name %>/
 /usr/share/applications/<%= name %>.desktop
 /usr/share/doc/<%= name %>/
 <% if (_.isObject(icon)) { %><% _.forEach(icon, function (path, resolution) { %>/usr/share/icons/hicolor/<%= resolution %>/apps/<%= name %>.png

--- a/src/installer.js
+++ b/src/installer.js
@@ -191,7 +191,7 @@ var createSpec = function (options, dir, callback) {
  */
 var createBinary = function (options, dir, callback) {
   var binDir = path.join(dir, 'BUILD/usr/bin')
-  var binSrc = path.join('../share', options.name, options.bin)
+  var binSrc = path.join('../lib', options.name, options.bin)
   var binDest = path.join(binDir, options.name)
   options.logger('Symlinking binary from ' + binSrc + ' to ' + binDest)
 
@@ -277,7 +277,7 @@ var createCopyright = function (options, dir, callback) {
  * Copy the application into the package.
  */
 var createApplication = function (options, dir, callback) {
-  var applicationDir = path.join(dir, 'BUILD/usr/share', options.name)
+  var applicationDir = path.join(dir, 'BUILD/usr/lib', options.name)
   options.logger('Copying application to ' + applicationDir)
 
   async.waterfall([


### PR DESCRIPTION
This was already addressed on the debian side with https://github.com/unindented/electron-installer-debian/pull/47 and for some reason, the change didn't happen on the redhat installer